### PR TITLE
ECO-5588: Updating file size upload validation

### DIFF
--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -540,8 +540,17 @@ export default class Dialog extends Component<DialogProps, DialogState> {
 
   openFileForm = (file: File, previewSource: string, showUpload: boolean) => {
 
-    // INKBOX NOTE: Check video file size - we don't want anything larger than 30MB
-    if (file.type.includes('video') && file.size > 30 * 1024 * 1024) {
+    // INKBOX NOTE: Check video file size - we don't want anything larger than 50MB
+    if (file.type.includes('video') && file.size > 50 * 1024 * 1024) {
+      this.setState({
+        errors: [fileTooLargeError()],
+      });
+
+      return;
+    }
+    
+    // INKBOX NOTE: Check image file size - we don't want anything larger than 10MB
+    if (file.type.includes('image') && file.size > 10 * 1024 * 1024) {
       this.setState({
         errors: [fileTooLargeError()],
       });


### PR DESCRIPTION
- Updating the allowable video size to 50MB
- Adding in validation for images to be limited to 10MB

---
Ticket: [ECO-5588](https://inkbox.atlassian.net/browse/ECO-5588)

[ECO-5588]: https://inkbox.atlassian.net/browse/ECO-5588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ